### PR TITLE
add command to replace double quoted instances of className

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
       {
         "command": "twind.restart",
         "title": "Twind: Restart IntelliSense"
+      },
+      {
+        "command": "twind.className",
+        "title": "Twind: Replace className strings"
       }
     ],
     "configuration": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,6 +83,25 @@ async function enableExtension(context: vscode.ExtensionContext, log: Logger) {
     }),
   )
 
+  const replaceClassNameStrings = () => {
+    const editor = vscode.window.activeTextEditor
+    if (editor) {
+      const document = editor.document
+      const selection = editor.selection
+      const word = document.getText(selection)
+      const replaced = word.replaceAll(/className="([^"].*)"/g, `className={tw\`$1\`}`)
+      editor.edit((editBuilder) => {
+        editBuilder.replace(selection, replaced)
+      })
+    }
+  }
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('twind.className', () => {
+      replaceClassNameStrings()
+    }),
+  )
+
   const twindWatcher = vscode.workspace.createFileSystemWatcher(
     '**/node_modules/twind/package.json',
   )


### PR DESCRIPTION
Hi there, thanks for this excellent extension.

I find myself pasting lots of HTML from the web (including TailwindUI, HeadlessUI, etc.) where React `className` is specified as a double quoted string. I want a VSCode command that replaces those strings with their `tw` wrapped content. This PR adds that function.